### PR TITLE
Always build Docker images for `linux/amd64` by default.

### DIFF
--- a/pkg/docker/v1/Makefile
+++ b/pkg/docker/v1/Makefile
@@ -16,6 +16,9 @@ DOCKER_BUILD_REQ +=
 # the "docker build" command.
 DOCKER_BUILD_ARGS +=
 
+# DOCKER_PLATFORM specifies the target platform for the Docker image.
+DOCKER_PLATFORM ?= linux/amd64
+
 ################################################################################
 
 # _DOCKER_TAG_TOUCH_FILES is a list of touch files for tagging Docker builds.
@@ -55,6 +58,7 @@ artifacts/docker/image-id/$(DOCKER_REPO): Dockerfile .dockerignore $(DOCKER_BUIL
 		--pull \
 		--build-arg "VERSION=$(SEMVER)" \
 		--iidfile "$@" \
+		--platform "$(DOCKER_PLATFORM)" \
 		$(DOCKER_BUILD_ARGS) \
 		.
 


### PR DESCRIPTION
This PR changes the Docker makefiles to explicitly and unconditionally pass the `--platform` flag to `docker build`. The target platform is specified by the `DOCKER_PLATFORM` variable, which defaults to `linux/amd64`, thus preventing builds on M1 macs from producing `linux/arm64` images.

This is a stop-gap solution until we can implement true multi-platform Docker builds, as described in #58.