### PR TITLE
replace go get with go install for go 1.16+

### DIFF
--- a/pkg/protobuf/v1/bin/install-protoc-gen-go
+++ b/pkg/protobuf/v1/bin/install-protoc-gen-go
@@ -19,7 +19,7 @@ for entry in "${packages[@]}"; do
 
     if version="$(go list -f '{{.Version}}' -m "$module" 2> /dev/null)"; then
         echo "installing $package@$version as per go.mod"
-        GOBIN="$1" go get "$package@$version"
+        GOBIN="$1" go install "$package@$version"
         exit
     fi
 done
@@ -33,6 +33,6 @@ for entry in "${packages[@]}"; do
     version="latest"
 
     echo "installing $package@$version by default"
-    GOBIN="$1" go get "$package@$version"
+    GOBIN="$1" go install "$package@$version"
     exit
 done

--- a/pkg/protobuf/v2/bin/install-protoc-gen-go
+++ b/pkg/protobuf/v2/bin/install-protoc-gen-go
@@ -23,9 +23,8 @@ if [ ! -f go.mod ]; then
 fi
 
 # Install the code generators into this "bin" module.
-go get \
-    "google.golang.org/protobuf/cmd/protoc-gen-go@$version" \
-    "google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest"
+go install "google.golang.org/protobuf/cmd/protoc-gen-go@$version"
+go install "google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest"
 
 # Touch the go.mod file so that it is no longer considered out of date by make,
 # even if nothing actually changed.


### PR DESCRIPTION
Replacing `go get` with `go install` as per deprecation notice.

Closes #61 