### PR TITLE
Add support for multi-platform docker builds.

### DIFF
--- a/pkg/docker/v1/Makefile
+++ b/pkg/docker/v1/Makefile
@@ -16,30 +16,57 @@ DOCKER_BUILD_REQ +=
 # the "docker build" command.
 DOCKER_BUILD_ARGS +=
 
-# DOCKER_PLATFORM specifies the target platform for the Docker image.
-DOCKER_PLATFORM ?= linux/amd64
+# DOCKER_PLATFORMS is a list of the target platforms for the Docker image.
+DOCKER_PLATFORMS ?= linux/amd64
 
 ################################################################################
 
-# _DOCKER_TAG_TOUCH_FILES is a list of touch files for tagging Docker builds.
-# The list is automatically generated from DOCKER_TAGS.
-_DOCKER_TAG_TOUCH_FILES := $(foreach TAG,$(DOCKER_TAGS),artifacts/docker/tag/$(DOCKER_REPO)/$(TAG).touch)
+# _DOCKER_PUSH_GUARDS is a list of phony targets that are used as prerequisites
+# to the docker-push target to prevent pushing "dev" tags.
+_DOCKER_PUSH_GUARDS := $(foreach TAG,$(DOCKER_TAGS),_docker-push-guard-$(TAG))
 
-# _DOCKER_PUSH_TOUCH_FILES is a list of touch files for pushing Docker tags. The
-# list is automatically generated from DOCKER_TAGS.
-_DOCKER_PUSH_TOUCH_FILES := $(foreach TAG,$(DOCKER_TAGS),artifacts/docker/push/$(DOCKER_REPO)/$(TAG).touch)
+# _DOCKER_BUILD_REQ is the union of DOCKER_BUILD_REQ and any other files that
+# are always considered prerequisites to Docker builds.
+_DOCKER_BUILD_REQ = Dockerfile .dockerignore $(DOCKER_BUILD_REQ)
+
+# _DOCKER_QUALIFIED_TAGS is the list of fully-qualified Docker image tags made
+# by concatenating DOCKER_REPO wich each value from DOCKER_TAGS. 
+_DOCKER_QUALIFIED_TAGS = $(foreach TAG,$(DOCKER_TAGS),$(DOCKER_REPO):$(TAG))
+
+# _DOCKER_QUALIFIED_TAGS_LIST and _DOCKER_PLATFORMS_LIST are comma-separated
+# versions of _DOCKER_QUALIFIED_TAGS and DOCKER_PLATFORMS, respectively.
+_DOCKER_QUALIFIED_TAGS_LIST = $(shell echo $(_DOCKER_QUALIFIED_TAGS) | tr ' ' ',')
+_DOCKER_PLATFORMS_LIST = $(shell echo $(DOCKER_PLATFORMS) | tr ' ' ',')
 
 ################################################################################
 
-# docker --- Builds a docker image from the Dockerfile in the root of the
-# repository.
+# docker --- Builds a docker image for the current platform and "loads" the
+# image into the local Docker server.
 .PHONY: docker
-docker: $(_DOCKER_TAG_TOUCH_FILES)
+docker: $(_DOCKER_BUILD_REQ)
+	docker buildx build \
+		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
+		--load \
+		.
 
-# docker-build --- Builds a docker image from the Dockerfile in the root of the
-# repository and pushes it to the registry.
+# docker-test --- Builds docker images for each target platform then
+# discards the result.
+.PHONY: docker
+docker-test: $(_DOCKER_BUILD_REQ)
+	docker buildx build \
+		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
+		--platform $(_DOCKER_PLATFORMS_LIST) \
+		.
+
+# docker-build --- Builds docker images for each target platform and pushes
+# those images, and a manifest list to the registry.
 .PHONY: docker-push
-docker-push: $(_DOCKER_PUSH_TOUCH_FILES)
+docker-push: $(_DOCKER_BUILD_REQ) $(_DOCKER_PUSH_GUARDS)
+	docker buildx build \
+		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
+		--platform $(_DOCKER_PLATFORMS_LIST) \
+		--push \
+		.
 
 ################################################################################
 
@@ -51,28 +78,10 @@ docker-push: $(_DOCKER_PUSH_TOUCH_FILES)
 	@echo .makefiles > "$@"
 	@echo .git >> "$@"
 
-artifacts/docker/image-id/$(DOCKER_REPO): Dockerfile .dockerignore $(DOCKER_BUILD_REQ)
-	@mkdir -p "$(@D)"
 
-	docker build \
-		--pull \
-		--build-arg "VERSION=$(SEMVER)" \
-		--iidfile "$@" \
-		--platform "$(DOCKER_PLATFORM)" \
-		$(DOCKER_BUILD_ARGS) \
-		.
-
-artifacts/docker/tag/$(DOCKER_REPO)/%.touch: artifacts/docker/image-id/$(DOCKER_REPO)
-	docker tag "$(shell cat "$<")" "$(DOCKER_REPO):$*"
-	@mkdir -p "$(@D)"
-	@touch "$@"
-
-.PHONY: artifacts/docker/push/$(DOCKER_REPO)/dev.touch
-artifacts/docker/push/$(DOCKER_REPO)/dev.touch:
+.PHONY: $(_DOCKER_PUSH_GUARDS)
+_docker-push-guard-dev:
 	@echo "The 'dev' tag can not be pushed to the registry, did you forget to set the DOCKER_TAGS environment variable?"
 	@exit 1
 
-artifacts/docker/push/$(DOCKER_REPO)/%.touch: artifacts/docker/tag/$(DOCKER_REPO)/%.touch
-	docker push "$(DOCKER_REPO):$*"
-	@mkdir -p "$(@D)"
-	@touch "$@"
+_docker-push-guard-%: 

--- a/pkg/docker/v1/Makefile
+++ b/pkg/docker/v1/Makefile
@@ -46,6 +46,8 @@ _DOCKER_PLATFORMS_LIST = $(shell echo $(DOCKER_PLATFORMS) | tr ' ' ',')
 docker: $(_DOCKER_BUILD_REQ)
 	docker buildx build \
 		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
+		--build-arg "VERSION=$(SEMVER)" \
+		--pull \
 		--load \
 		.
 
@@ -56,6 +58,8 @@ docker-test: $(_DOCKER_BUILD_REQ)
 	docker buildx build \
 		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
 		--platform $(_DOCKER_PLATFORMS_LIST) \
+		--build-arg "VERSION=$(SEMVER)" \
+		--pull \
 		.
 
 # docker-build --- Builds docker images for each target platform and pushes
@@ -65,6 +69,8 @@ docker-push: $(_DOCKER_BUILD_REQ) $(_DOCKER_PUSH_GUARDS)
 	docker buildx build \
 		--tag $(_DOCKER_QUALIFIED_TAGS_LIST) \
 		--platform $(_DOCKER_PLATFORMS_LIST) \
+		--build-arg "VERSION=$(SEMVER)" \
+		--pull \
 		--push \
 		.
 

--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -119,8 +119,8 @@ _GO_RELEASE_TARGETS_ALL  = $(addprefix artifacts/build/release/,$(_GO_BUILD_MATR
 _GO_RELEASE_TARGETS_HOST = $(addprefix artifacts/build/release/,$(_GO_BUILD_MATRIX_HOST))
 .SECONDARY: $(_GO_RELEASE_TARGETS_HOST)
 
-# Ensure that Linux release binaries are built before attempting to build a Docker image.
-DOCKER_BUILD_REQ += $(addprefix artifacts/build/release/linux/amd64/,$(_GO_BINARIES_NIX))
+# Ensure that release binaries are built before attempting to build a Docker image.
+DOCKER_BUILD_REQ += $(foreach PLATFORM,$(DOCKER_PLATFORMS),$(addprefix artifacts/build/release/$(PLATFORM)/,$(_GO_BINARIES_NIX)))
 
 ifneq ($(GO_BUILD_BEFORE_TEST),)
 GO_TEST_REQ += $(_GO_DEBUG_TARGETS_HOST)


### PR DESCRIPTION
- Fixes #58 
- Fixes #55

This is a first-draft PR for the multi-platform docker builds.  I wanted to submit this now to get some early feedback.

- I've changed the recently added `DOCKER_PLATFORM` variable to `DOCKER_PLATFORMS`. It is now space separated list of Docker platforms, such as `linux/arm64`, `linux/amd64`, etc.
- `make docker` now builds an image for the **current** platform and "loads" it (to use `buildx` terminology) into Docker so that it can be used. I theorise that this is our most common use case for `make docker`.
- The new `make docker-test` target builds images for all target platforms then discards the results. This is intended to replace the use of `make docker` under CI when we aren't pushing. The build results are discarded insofar as they are not made available to Docker itself, but they do remain in the build agent's cache. I've done it this way due to a (seemingly temporary) limitation with `buildx` wherein it can not "load" the manifests required for multi-platform images into Docker.
- `make docker-push` builds and pushes images for all target architectures, and the "manifest list" to the registry. The manifest list is the thing that makes automatic selection of the correct image work.

At this point I've done away with any notion of touch files for simplicity.

Lastly, I've updated the Go makefile so that it builds binaries for all of the target platforms based on `DOCKER_PLATFORM`, it was previously hardcoded to `linux/amd64`. This is a partial solution that works for _most_ platforms because Docker and Go tend to use the same strings to refer to them. It will not work for ARM builds other than `arm64` as Docker and Go use different strings to represent those. We'll need to add some mapping here.