### PR TITLE
Add `MF_LANGUAGES` variable.

### DIFF
--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -1,3 +1,5 @@
+MF_LANGUAGES += go
+
 # Always run tests by default, even if other makefiles are included beforehand.
 .DEFAULT_GOAL := test
 

--- a/pkg/js/v1/Makefile
+++ b/pkg/js/v1/Makefile
@@ -1,3 +1,5 @@
+MF_LANGUAGES += js
+
 # Always run tests by default, even if other makefiles are included beforehand.
 .DEFAULT_GOAL := test
 

--- a/pkg/php/v1/Makefile
+++ b/pkg/php/v1/Makefile
@@ -1,3 +1,5 @@
+MF_LANGUAGES += php
+
 # Always run tests by default, even if other makefiles are included beforehand.
 .DEFAULT_GOAL := test
 


### PR DESCRIPTION
This PR adds the MF_LANGUAGES variable, a whitespace separated list of the language files that have been included.
I deliberately didn't include non-language packages like `protobuf` and `docker`.

You can check if a language is in this like like so:

```Makefile
ifneq ($(filter go,$(MF_LANGUAGES)),) # note use of NOT equal
    $(info go is in the list)
endif
```