### PR TITLE
Make DOCKER_BUILD_ARGS Work Again

### DIFF
--- a/pkg/docker/v1/Makefile
+++ b/pkg/docker/v1/Makefile
@@ -43,7 +43,7 @@ _DOCKER_PLATFORM_FLAG = --platform $(shell echo $(DOCKER_PLATFORMS) | tr ' ' ','
 docker: $(_DOCKER_BUILD_REQ)
 	docker buildx build \
 		$(_DOCKER_TAG_FLAGS) \
-		--build-arg "VERSION=$(SEMVER)" \
+		$(DOCKER_BUILD_ARGS) --build-arg "VERSION=$(SEMVER)" \
 		--pull \
 		--load \
 		.
@@ -55,7 +55,7 @@ docker-test: $(_DOCKER_BUILD_REQ)
 	docker buildx build \
 		$(_DOCKER_TAG_FLAGS) \
 		$(_DOCKER_PLATFORM_FLAG) \
-		--build-arg "VERSION=$(SEMVER)" \
+		$(DOCKER_BUILD_ARGS) --build-arg "VERSION=$(SEMVER)" \
 		--pull \
 		.
 
@@ -66,7 +66,7 @@ docker-push: $(_DOCKER_BUILD_REQ) $(_DOCKER_PUSH_GUARDS)
 	docker buildx build \
 		$(_DOCKER_TAG_FLAGS) \
 		$(_DOCKER_PLATFORM_FLAG) \
-		--build-arg "VERSION=$(SEMVER)" \
+		$(DOCKER_BUILD_ARGS) --build-arg "VERSION=$(SEMVER)" \
 		--pull \
 		--push \
 		.


### PR DESCRIPTION
`DOCKER_BUILD_ARGS` was (I assume) accidentally left out when docker was updated to use `buildx`.

Just adding it back in.