### PR TITLE
Improve `git-find`

### DIFF
--- a/lib/core/bin/git-find
+++ b/lib/core/bin/git-find
@@ -3,15 +3,31 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../include/common.bash"
 
 if [[ $# < 1 ]]; then
-    echo "Usage: git-find pattern"
+    echo "Usage: git-find pathname ..."
     echo
-    echo "  Lists files within the Git repository that match the given filename"
-    echo "  pattern. Files ignored by Git are not included in the output."
+    echo "  A wrapper around the find command that excludes files ignored by"
+    echo "  Git. Only supports a single pathname argument, relative to the"
+    echo "  project root. No additional pathnames may be specified with -f."
+    echo "  Because Git has no knowledge of directories, this command will only"
+    echo "  ever find files, not directories."
     echo
     exit 1
 fi
 
 cd "$MF_PROJECT_ROOT"
-files="$(git ls-files; git ls-files --other --exclude-standard)"
+
+# git ls-files -- "$1"
+#    lists all files in the repository under the specified path, including those
+#    in the staging area
+# git ls-files --other --exclude-standard -- "$1"
+#    lists all untracked files under the specified path, except those ignored by
+#    Git
+files="$(git ls-files -- "$1"; git ls-files --other --exclude-standard -- "$1")"
+
+# filter out any non-existent paths to prevent subsequent find calls from
+# producing "No such file or directory" errors
 files="$(find $files 2>/dev/null || true)"
-[[ -n "$files" ]] && find $files -type f -iname "$1"
+
+# [[ -n "$files" ]]
+#    do not run find unless there are some files to match
+[[ -n "$files" ]] && find $files "${@:2}"

--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -17,7 +17,7 @@ GO_ARCHIVE_FILES +=
 
 # GO_SOURCE_FILES is a space separated list of source files that are used by the
 # build process.
-GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.go')
+GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.go')
 
 # GO_EMBEDDED_FILES is a space separated list of files that are embedded into
 # the Go binary using the standard "embed" package.

--- a/pkg/js/v1/Makefile
+++ b/pkg/js/v1/Makefile
@@ -4,7 +4,7 @@ MF_LANGUAGES += js
 .DEFAULT_GOAL := test
 
 # JS_SOURCE_FILES is a space separated list of source files in the repo.
-JS_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.js')
+JS_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.js')
 
 # JS_ESLINT_CONFIG_FILE is the path to any existing ESLint configuration.
 JS_ESLINT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file .eslintrc.* .eslintrc)

--- a/pkg/php/v1/Makefile
+++ b/pkg/php/v1/Makefile
@@ -4,7 +4,7 @@ MF_LANGUAGES += php
 .DEFAULT_GOAL := test
 
 # PHP_SOURCE_FILES is a space separated list of source files in the repo.
-PHP_SOURCE_FILES += $(shell PATH="$(PATH)" git-find '*.php')
+PHP_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.php')
 
 # PHP_CS_FIXER_CONFIG_FILE is the path to any existing PHP CS Fixer
 # configuration.

--- a/pkg/protobuf/v1/Makefile
+++ b/pkg/protobuf/v1/Makefile
@@ -1,5 +1,5 @@
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find '*.proto')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto')
 
 # PROTO_INCLUDE_PATHS is a space separate list of include paths to use when
 # building the .proto files from this repository.

--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -1,5 +1,5 @@
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find '*.proto')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto')
 
 # PROTO_GRPC_FILES is the subset of PROTO_FILES that contain gRPC service
 # definitions.


### PR DESCRIPTION
This PR improves `git-find` by adding the ability to specify sub-paths and arbitrary `find` arguments. Previously it was not possible to narrow the list of results to files in a particular directory, and this is desirable for some of the use cases in the JS makefiles.

- Existing usage of `git-find` will be updated
- Args to `find` will use `-name` instead of `-iname` because I don't think we ever actually use uppercase file extensions