### PR TITLE
Add Protobuf include paths only if a Go module directory contains *.proto files

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -88,4 +88,4 @@ artifacts/protobuf/args/common:
 artifacts/protobuf/args/go: go.mod
 	go mod download all
 	@mkdir -p "$(@D)"
-	go list -f "--proto_path={{if .Dir}}{{ .Path }}={{ .Dir }}{{end}}" -m all > "$@"
+	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-include-paths > "$@"

--- a/pkg/protobuf/v2/bin/generate-include-paths
+++ b/pkg/protobuf/v2/bin/generate-include-paths
@@ -7,9 +7,7 @@ for i in "${go_modules[@]}"
 do
     path="${i%=*}"
     dir="${i#*=}"
-    proto_file_count=$(find $dir -type f -iname '*.proto' | wc -l)
-
-    if [[ $proto_file_count -gt 0 ]]; then
+    if find "$dir" -type f -iname '*.proto' > /dev/null; then
        # Print the protobuf include path to the standard output
        # if the Go module directory contains *.proto files.
        echo "--proto_path=$path=$dir"

--- a/pkg/protobuf/v2/bin/generate-include-paths
+++ b/pkg/protobuf/v2/bin/generate-include-paths
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+go_modules=($(go list -f '{{.Path}}={{.Dir}} ' -m all))
+
+for i in "${go_modules[@]}"
+do
+    path="${i%=*}"
+    dir="${i#*=}"
+    proto_file_count=$(find $dir -type f -iname '*.proto' | wc -l)
+
+    if [[ $proto_file_count -gt 0 ]]; then
+       # Print the protobuf include path to the standard output
+       # if the Go module directory contains *.proto files.
+       echo "--proto_path=$path=$dir"
+    fi
+done


### PR DESCRIPTION
This PR changes the logic of adding protobuf include paths as options to the protobuf compiler. The new logic adds the include path only if a Go module directory contains *.proto files.