### PR TITLE
Change to new protoc versioning.

### DIFF
--- a/pkg/protobuf/v2/bin/install-protoc
+++ b/pkg/protobuf/v2/bin/install-protoc
@@ -15,10 +15,6 @@ esac
 
 ARCH="$(uname -m)"
 
-# Use x86_64 on Apple Silicon, as there is no official arm64 support.
-#
-# See https://github.com/protocolbuffers/protobuf/issues/8062.
-# See https://github.com/protocolbuffers/protobuf/issues/8428.
 if [[ "$OS" == "osx" && "$ARCH" == "arm64" ]]; then
     ARCH="aarch_64"
 fi

--- a/pkg/protobuf/v2/bin/install-protoc
+++ b/pkg/protobuf/v2/bin/install-protoc
@@ -20,11 +20,10 @@ ARCH="$(uname -m)"
 # See https://github.com/protocolbuffers/protobuf/issues/8062.
 # See https://github.com/protocolbuffers/protobuf/issues/8428.
 if [[ "$OS" == "osx" && "$ARCH" == "arm64" ]]; then
-    softwareupdate --install-rosetta --agree-to-license
-    ARCH="x86_64"
+    ARCH="aarch_64"
 fi
 
-VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+.[0-9]+')"
+VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+')"
 
 if [[ -f "${PROTOC_ROOT}/bin/protoc" ]]; then
     LOCAL_VERSION="$(${PROTOC_ROOT}/bin/protoc --version | sed -e 's/.* //')"


### PR DESCRIPTION
This PR changes the logic of detecting the latest protoc compiler version
to the new versioning system adapted by Google. More about the new versioning
can be read at https://github.com/protocolbuffers/protobuf/releases/tag/v21.0-rc1.

This PR also enables the downloading of compiler binary of AARCH64 architechture
for OSX as the AARCH64 OSX compilation was finally fixed in
https://github.com/protocolbuffers/protobuf/releases/tag/v21.0-rc2