### PR TITLE
Add run-protoc script.

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -58,16 +58,16 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 #
 # NOTE: The $$(cat ...) syntax can NOT be swapped to $$(< ...). For reasons
 # unknown this syntax does NOT work under Travis CI.
-%.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/args/common artifacts/protobuf/args/go
-	PATH="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin:$$PATH" $(PROTOC_COMMAND) \
+%.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
+	$(MF_PROJECT_ROOT)/artifacts/protobuf/bin/run-protoc \
 		--proto_path="$(dir $(PROTOC_COMMAND))../include" \
 		--go_opt=module=$$(go list -m) \
 		--go_out=:. \
 		$$(cat artifacts/protobuf/args/common artifacts/protobuf/args/go) \
 		$(MF_PROJECT_ROOT)/$(@D)/*.proto
 
-%_grpc.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/args/common artifacts/protobuf/args/go
-	PATH="$(MF_PROJECT_ROOT)/artifacts/protobuf/bin:$$PATH" $(PROTOC_COMMAND) \
+%_grpc.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
+	$(MF_PROJECT_ROOT)/artifacts/protobuf/bin/run-protoc \
 		--proto_path="$(dir $(PROTOC_COMMAND))../include" \
 		--go-grpc_opt=module=$$(go list -m) \
 		--go-grpc_out=. \
@@ -77,6 +77,9 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 
 $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc:
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
+
+artifacts/protobuf/bin/run-protoc:
+	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-protoc-run $(PROTOC_COMMAND)
 
 artifacts/protobuf/bin/go.mod: go.mod
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"

--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -58,7 +58,7 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 #
 # NOTE: The $$(cat ...) syntax can NOT be swapped to $$(< ...). For reasons
 # unknown this syntax does NOT work under Travis CI.
-%.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
+%.pb.go: %.proto artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
 	$(MF_PROJECT_ROOT)/artifacts/protobuf/bin/run-protoc \
 		--proto_path="$(dir $(PROTOC_COMMAND))../include" \
 		--go_opt=module=$$(go list -m) \
@@ -66,7 +66,7 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 		$$(cat artifacts/protobuf/args/common artifacts/protobuf/args/go) \
 		$(MF_PROJECT_ROOT)/$(@D)/*.proto
 
-%_grpc.pb.go: %.proto $(PROTOC_COMMAND) artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
+%_grpc.pb.go: %.proto artifacts/protobuf/bin/go.mod artifacts/protobuf/bin/run-protoc artifacts/protobuf/args/common artifacts/protobuf/args/go
 	$(MF_PROJECT_ROOT)/artifacts/protobuf/bin/run-protoc \
 		--proto_path="$(dir $(PROTOC_COMMAND))../include" \
 		--go-grpc_opt=module=$$(go list -m) \
@@ -78,8 +78,8 @@ PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc:
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
 
-artifacts/protobuf/bin/run-protoc:
-	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-protoc-run $(PROTOC_COMMAND)
+artifacts/protobuf/bin/run-protoc: $(PROTOC_COMMAND)
+	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-run-protoc $(PROTOC_COMMAND)
 
 artifacts/protobuf/bin/go.mod: go.mod
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"

--- a/pkg/protobuf/v2/bin/generate-protoc-run
+++ b/pkg/protobuf/v2/bin/generate-protoc-run
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+
+dir=$(dirname $1)
+script_name="run-protoc"
+
+$(cat <<EOF > "${dir}/${script_name}"
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script runs a local copy of protoc compiler and sets its path as a part
+# of PATH environment variable.
+PATH="${dir}:\$PATH" \\
+"$1" "\${@}"
+EOF
+)
+
+chmod +x "${dir}/${script_name}"

--- a/pkg/protobuf/v2/bin/generate-run-protoc
+++ b/pkg/protobuf/v2/bin/generate-run-protoc
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-
-dir=$(dirname $1)
+protoc_path=$1
+dir=$(dirname "${protoc_path}")
 script_name="run-protoc"
 
 $(cat <<EOF > "${dir}/${script_name}"
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script runs a local copy of protoc compiler and sets its path as a part
-# of PATH environment variable.
+# Configure PATH so that the protoc plugins installed by the Makefiles take
+# precedence.
 PATH="${dir}:\$PATH" \\
 "$1" "\${@}"
 EOF


### PR DESCRIPTION
This PR adds `run-protoc` script to the `pkg/protobuf/v2/bin` folder. This script adds `pkg/protobuf/v2/bin` directory to the `$PATH` environment variable to enable the execution of local copy of `protoc` and all associated language plugins (currently represented by a Golang plugin).