### PR TITLE
Disable "Old-Fashioned Suffix Rules"

### DIFF
--- a/lib/core/include/common.mk
+++ b/lib/core/include/common.mk
@@ -1,3 +1,9 @@
+# Remove all "Old-Fashioned Suffix Rules" to simplify make -d output when
+# debugging.
+#
+# See https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html
+.SUFFIXES:
+
 export MF_PROJECT_ROOT := $(realpath $(dir $(word 1,$(MAKEFILE_LIST))))
 export MF_ROOT := $(MF_PROJECT_ROOT)/.makefiles
 export PATH := $(MF_ROOT)/lib/core/bin:$(PATH)


### PR DESCRIPTION
This PR drastically reduces the output produced when debugging Makefiles with `make -d`.  See https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html

Example `make -d` line count before and after:

```shell
$ make -d makefiles | wc -l # before PR
    1370

$ make -d makefiles | wc -l # after PR
     131
```