### PR TITLE
Add support for random telepresence ports.

### DIFF
--- a/pkg/telepresence/v1/Makefile
+++ b/pkg/telepresence/v1/Makefile
@@ -3,10 +3,16 @@ ifndef TELEPRESENCE_SERVICE_NAME
 $(error "TELEPRESENCE_SERVICE_NAME must be defined in the project's Makefile.")
 endif
 
-# TELEPRESENCE_SERVICE_PORT is the port to intercept.
-ifndef TELEPRESENCE_SERVICE_PORT
-$(error "TELEPRESENCE_SERVICE_PORT must be defined in the project's Makefile.")
-endif
+# _TELEPRESENCE_RANDOM_PORT is a random port in the high range, used by default
+# if TELEPRESENCE_SERVICE_PORT is not defined.
+#
+# It must be assigned to a variable with the := operator so that it is EAGERLY
+# evaluated. Otherwise, it is evaluated each time the variable is used which
+# gives a different random por teach time.
+_TELEPRESENCE_RANDOM_PORT := $(shell echo $$((32768 + $$RANDOM)))
+
+# TELEPRESENCE_SERVICE_PORT is the name or number of the port to intercept.
+TELEPRESENCE_SERVICE_PORT ?= $(_TELEPRESENCE_RANDOM_PORT)
 
 # TELEPRESENCE_RUN_CMD is the command to use to start a local server for an
 # intercept.
@@ -16,11 +22,15 @@ TELEPRESENCE_RUN_CMD ?= make run
 
 .PHONY: intercept
 intercept: pre-intercept
-	CGO_ENABLED=true telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(shell echo $$SHELL)
+	CGO_ENABLED=true \
+	TELEPRESENCE_SERVICE_PORT=$(TELEPRESENCE_SERVICE_PORT) \
+		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(shell echo $$SHELL)
 
 .PHONY: intercept-run
 intercept-run: pre-intercept-run
-	CGO_ENABLED=true telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(TELEPRESENCE_RUN_CMD)
+	CGO_ENABLED=true \
+	TELEPRESENCE_SERVICE_PORT=$(TELEPRESENCE_SERVICE_PORT) \
+		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(TELEPRESENCE_RUN_CMD)
 
 .PHONY: pre-intercept
 pre-intercept::


### PR DESCRIPTION
This PR adds (optional) support for randomly generating the local port used by a Telepresence intercept.

Prior to this PR the `TELEPRESENCE_SERVICE_PORT` Makefile variable was *mandatory*.  Now it is optional, and if undefined a random port is used.

An environment variable of the same name (`TELEPRESENCE_SERVICE_PORT`) is now defined while intercepting. Services can use this environment variable to determine which port they should listen on, typically by assigning to another existing environment variable in the `run:` target.

Note that the port selection is purely random, it does not check if the port is free for use. If there is a collision, Telepresence will fail with a "port in use" error message and the user can simply re-run the command. In practice this solution works well, I've not yet seen any collisions so I don't feel it warrants the extra effort that would be needed to select an unused port in a cross-platform way.