### PR TITLE
Allow Telepresence remote ports to be specified

### DIFF
--- a/pkg/telepresence/v1/Makefile
+++ b/pkg/telepresence/v1/Makefile
@@ -11,12 +11,26 @@ endif
 # gives a different random por teach time.
 _TELEPRESENCE_RANDOM_PORT := $(shell echo $$((32768 + $$RANDOM)))
 
-# TELEPRESENCE_SERVICE_PORT is the name or number of the port to intercept.
+# TELEPRESENCE_SERVICE_PORT is the local port to use to handle an intercept.
 TELEPRESENCE_SERVICE_PORT ?= $(_TELEPRESENCE_RANDOM_PORT)
+
+# TELEPRESENCE_SERVICE_REMOTE_PORT is the remote port name or number that should
+# be intercepted.
+#
+# It is only necessary to set this in the case that a service uses multiple
+# ports. It is recommended to use a port name (not a number) if you can.
+TELEPRESENCE_SERVICE_REMOTE_PORT ?=
 
 # TELEPRESENCE_RUN_CMD is the command to use to start a local server for an
 # intercept.
 TELEPRESENCE_RUN_CMD ?= make run
+
+# _TELEPRESENCE_PORT_MAPPING is the argument passed to Telepresence's --port
+# option when creating an intercept.
+#
+# If the TELEPRESENCE_SERVICE_REMOTE_PORT variable is defined, it will be in the
+# format <local port>:<remote port>, otherwise it will be just <local port>.
+_TELEPRESENCE_PORT_MAPPING = $(if $(TELEPRESENCE_SERVICE_REMOTE_PORT),$(TELEPRESENCE_SERVICE_PORT):$(TELEPRESENCE_SERVICE_REMOTE_PORT),$(TELEPRESENCE_SERVICE_PORT))
 
 ################################################################################
 
@@ -24,13 +38,13 @@ TELEPRESENCE_RUN_CMD ?= make run
 intercept: pre-intercept
 	CGO_ENABLED=true \
 	TELEPRESENCE_SERVICE_PORT=$(TELEPRESENCE_SERVICE_PORT) \
-		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(shell echo $$SHELL)
+		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(_TELEPRESENCE_PORT_MAPPING) -- $(shell echo $$SHELL)
 
 .PHONY: intercept-run
 intercept-run: pre-intercept-run
 	CGO_ENABLED=true \
 	TELEPRESENCE_SERVICE_PORT=$(TELEPRESENCE_SERVICE_PORT) \
-		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(TELEPRESENCE_SERVICE_PORT) -- $(TELEPRESENCE_RUN_CMD)
+		telepresence intercept $(TELEPRESENCE_SERVICE_NAME) --port $(_TELEPRESENCE_PORT_MAPPING) -- $(TELEPRESENCE_RUN_CMD)
 
 .PHONY: pre-intercept
 pre-intercept::


### PR DESCRIPTION
This PR adds a mechanism to specify a default remote port to use for Telepresence intercepts.

Expected usage in a multi-port project's `Makefile`:

```Makefile
TELEPRESENCE_SERVICE_REMOTE_PORT ?= api
```

Then to intercept the default port, run commands like:

```
make intercept
make intercept-run
```

Or to intercept a different port, run commands like:

```
TELEPRESENCE_SERVICE_REMOTE_PORT=observability make intercept
TELEPRESENCE_SERVICE_REMOTE_PORT=observability make intercept-run
```