### PR TITLE
Show git log subject lines only

### DIFF
--- a/pkg/changelog/v1/bin/tag-editor
+++ b/pkg/changelog/v1/bin/tag-editor
@@ -34,7 +34,7 @@ if [ -f CHANGELOG.md ]; then
 fi
 
 # GIT_LOG gets git log messages since the last tag to the editor
-GIT_LOG=$(git log --pretty=format:'- '%s%n%b%- --first-parent ..."$(git describe --abbrev=0 2> /dev/null)")
+GIT_LOG=$(git log --pretty=format:'- '%s%- --first-parent ..."$(git describe --abbrev=0 2> /dev/null)")
 
 if [ ! -z "${GIT_LOG}" ]; then
     echo "<!------------------ Everything past this line will be deleted ----------------------->" >> "$TEMP_FILE_TAG"


### PR DESCRIPTION
Resolves #101

Currently `GIT_LOG` holds all commit subjects (%s), a newline (%n), and the body (%b) which looks like this:

```
- Commit subject 2
Commit body 2
- Commit subject 1
Commit body 1
```

This is then processed as if each line was a subject. So if a line in the commit body contains "Add" that line will be moved to the `Added` section cutting it off of the subject which doesn't seem intended.

This change means `GIT_LOG` will look like this instead (subject line only).

```
- Commit subject 2
- Commit subject 1
```