### PR TITLE
add support for linux/arm64 to protobuf

### DIFF
--- a/pkg/protobuf/v2/bin/install-protoc
+++ b/pkg/protobuf/v2/bin/install-protoc
@@ -37,7 +37,9 @@ mkdir -p "${PROTOC_ROOT}"
 pushd "${PROTOC_ROOT}"
 curl --fail --silent --show-error --location --output "${ARCHIVE}" "${URL}"
 unzip -o "${ARCHIVE}"
-[[ ! -x bin/protoc ]] && chmod +x bin/protoc
+if [[ ! -x bin/protoc ]]; then ## if bin/protoc already executable, skip chmod, see PR#107.
+    chmod +x bin/protoc
+fi
 find include/google -type d -exec chmod 755 {} \;
 find include/google -type f -exec chmod 644 {} \;
 popd

--- a/pkg/protobuf/v2/bin/install-protoc
+++ b/pkg/protobuf/v2/bin/install-protoc
@@ -19,6 +19,10 @@ if [[ "$OS" == "osx" && "$ARCH" == "arm64" ]]; then
     ARCH="aarch_64"
 fi
 
+if [[ "$OS" == "linux" && "$ARCH" == "aarch64" ]]; then
+    ARCH="aarch_64"
+fi
+
 VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+')"
 
 if [[ -f "${PROTOC_ROOT}/bin/protoc" ]]; then
@@ -33,7 +37,7 @@ mkdir -p "${PROTOC_ROOT}"
 pushd "${PROTOC_ROOT}"
 curl --fail --silent --show-error --location --output "${ARCHIVE}" "${URL}"
 unzip -o "${ARCHIVE}"
-chmod +x bin/protoc
+[[ ! -x bin/protoc ]] && chmod +x bin/protoc
 find include/google -type d -exec chmod 755 {} \;
 find include/google -type f -exec chmod 644 {} \;
 popd


### PR DESCRIPTION
# Summary

Minor changes, I did some testing, but it should only affect the targeted platforms (which would already have failed).

# Details

Added support for `linux/arm64` to protobuf/v2.

```shell
kosh@rpi-2fdf68c9:~ $ uname -m
aarch64
```

but the binary download is aarch_64 (same as `darwin/arm64`).

# Bonus Round

Using docker volumes that don't support chmod (which most of the time have a mask for files so they are already +x) it tests first if the file is not +x and only runs the chmod if needed, so if it fails, then it wouldn't have worked, instead of failing (pipefail) when if ignored the result would have run.

Change logic is simple and sound, can't think of any cases where it would fail only on that line.