### PR TITLE
Add counter to test-until-failure for failure report and success separator

### DIFF
--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -176,7 +176,10 @@ test:: $(GENERATED_FILES) $(GO_TEST_REQ)
 # test-until-failure --- Execute all go tests in this module until they fail.
 .PHONY: test-until-failure
 test-until-failure:
-	while go test -count=1 $(GO_TEST_ARGS) ./...; do :; done
+	@counter=0; while go test -count=1 $(GO_TEST_ARGS) ./...; do \
+		counter=$$(expr $$counter + 1); \
+		echo "----------| Test Run $$counter Succeeded |----------"; \
+	done; echo "Test(s) failed after $$counter successful runs"
 
 # benchmark --- Executes all go benchmarks (but not tests) in this module.
 .PHONY: benchmark

--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -178,8 +178,8 @@ test:: $(GENERATED_FILES) $(GO_TEST_REQ)
 test-until-failure:
 	@counter=0; while go test -count=1 $(GO_TEST_ARGS) ./...; do \
 		counter=$$(expr $$counter + 1); \
-		echo "----------| Test Run $$counter Succeeded |----------"; \
-	done; echo "Test(s) failed after $$counter successful runs"
+		echo "--- test run $$counter succeeded"; \
+	done; echo "--- failed after $$counter successful run(s)"
 
 # benchmark --- Executes all go benchmarks (but not tests) in this module.
 .PHONY: benchmark


### PR DESCRIPTION
Uses POSIX shell compliant `expr` in an attempt to provide maximum compatibility.