### PR TITLE
fix m1 macos and v1 protobuf binary install

### DIFF
--- a/pkg/protobuf/v1/bin/install-protoc
+++ b/pkg/protobuf/v1/bin/install-protoc
@@ -13,14 +13,24 @@ case "$(uname -s)" in
         OS="linux";;
 esac
 
-VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+.[0-9]+')"
+ARCH="$(uname -m)"
+
+if [[ "$OS" == "osx" && "$ARCH" == "arm64" ]]; then
+    ARCH="aarch_64"
+fi
+
+if [[ "$OS" == "linux" && "$ARCH" == "aarch64" ]]; then
+    ARCH="aarch_64"
+fi
+
+VERSION="$(curl --head --silent https://github.com/protocolbuffers/protobuf/releases/latest | grep -i '^Location:' | egrep -o '[0-9]+.[0-9]+(.[0-9]+)?')"
 
 if [[ -f "${PROTOC_ROOT}/bin/protoc" ]]; then
     LOCAL_VERSION="$(${PROTOC_ROOT}/bin/protoc --version | sed -e 's/.* //')"
     [[ "${VERSION}" == "${LOCAL_VERSION}" ]] && exit 0
 fi
 
-ARCHIVE="protoc-${VERSION}-${OS}-$(uname -m).zip"
+ARCHIVE="protoc-${VERSION}-${OS}-${ARCH}.zip"
 URL="https://github.com/protocolbuffers/protobuf/releases/download/v${VERSION}/${ARCHIVE}"
 
 mkdir -p "${PROTOC_ROOT}"


### PR DESCRIPTION
Similar to the fix for the v2 protobuf Makefile, adding rename for arm64 architecture.

```shell
$ make test
/grit/github.com/na4ma4/vendortest/vendor-deps/github.com/jmalloc/ax/.makefiles/pkg/protobuf/v1/bin/install-protoc "/grit/github.com/na4ma4/vendortest/vendor-deps/github.com/jmalloc/ax/artifacts/protobuf"
make: *** [/grit/github.com/na4ma4/vendortest/vendor-deps/github.com/jmalloc/ax/artifacts/protobuf/bin/protoc] Error 1
```