### PR TITLE
[golang] ignore files and paths that start with an underscore

### DIFF
--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -17,7 +17,7 @@ GO_ARCHIVE_FILES +=
 
 # GO_SOURCE_FILES is a space separated list of source files that are used by the
 # build process.
-GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.go')
+GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.go' -not -regex '.*/_.*')
 
 # GO_EMBEDDED_FILES is a space separated list of files that are embedded into
 # the Go binary using the standard "embed" package.

--- a/pkg/protobuf/v1/Makefile
+++ b/pkg/protobuf/v1/Makefile
@@ -1,5 +1,5 @@
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '.*/_.*')
 
 # PROTO_INCLUDE_PATHS is a space separate list of include paths to use when
 # building the .proto files from this repository.

--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -1,7 +1,7 @@
 MF_LANGUAGES += proto
 
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '.*/_.*')
 
 # PROTO_GRPC_FILES is the subset of PROTO_FILES that contain gRPC service
 # definitions.


### PR DESCRIPTION
Inline with `go build` [documentation](https://pkg.go.dev/go/build#Context.Import):

In the directory

>  containing the package, .go, .c, .h, and .s files are considered part of the package except for:
> 
> - .go files in package documentation
> - files starting with _ or . (likely editor temporary files)
> - files with build constraints not satisfied by the context
>
> If an error occurs, Import returns a non-nil error and a non-nil *Package containing partial information.

Testing command changes:

<details>
  <summary>Complete file list</summary>

```shell
$ find . -name '*.go'
./nounderscore/nounderscore/_hasunderscore.go
./nounderscore/nounderscore/has_underscore.go
./nounderscore/nounderscore/nounderscore.go
./nounderscore/_hasunderscore/_hasunderscore.go
./nounderscore/_hasunderscore/has_underscore.go
./nounderscore/_hasunderscore/nounderscore.go
./nounderscore/has_underscore/_hasunderscore.go
./nounderscore/has_underscore/has_underscore.go
./nounderscore/has_underscore/nounderscore.go
./_hasunderscore/nounderscore/_hasunderscore.go
./_hasunderscore/nounderscore/has_underscore.go
./_hasunderscore/nounderscore/nounderscore.go
./_hasunderscore/_hasunderscore/_hasunderscore.go
./_hasunderscore/_hasunderscore/has_underscore.go
./_hasunderscore/_hasunderscore/nounderscore.go
./_hasunderscore/has_underscore/_hasunderscore.go
./_hasunderscore/has_underscore/has_underscore.go
./_hasunderscore/has_underscore/nounderscore.go
./has_underscore/nounderscore/_hasunderscore.go
./has_underscore/nounderscore/has_underscore.go
./has_underscore/nounderscore/nounderscore.go
./has_underscore/_hasunderscore/_hasunderscore.go
./has_underscore/_hasunderscore/has_underscore.go
./has_underscore/_hasunderscore/nounderscore.go
./has_underscore/has_underscore/_hasunderscore.go
./has_underscore/has_underscore/has_underscore.go
./has_underscore/has_underscore/nounderscore.go
```
</details>

<details>
  <summary>find using `-regex` on macOS</summary>

```shell
$ find . -name '*.go' -not -regex '.*/_.*'
./nounderscore/nounderscore/has_underscore.go
./nounderscore/nounderscore/nounderscore.go
./nounderscore/has_underscore/has_underscore.go
./nounderscore/has_underscore/nounderscore.go
./has_underscore/nounderscore/has_underscore.go
./has_underscore/nounderscore/nounderscore.go
./has_underscore/has_underscore/has_underscore.go
./has_underscore/has_underscore/nounderscore.go
```
</details>

<details>
  <summary>find using `-regex` on ubuntu:jammy</summary>

```shell
$ docker run -ti --rm -v "$(pwd):$(pwd)" --workdir "$(pwd)" ubuntu:jammy find . -name '*.go' -not -regex '.*/_.*'
./nounderscore/nounderscore/has_underscore.go
./nounderscore/nounderscore/nounderscore.go
./nounderscore/has_underscore/has_underscore.go
./nounderscore/has_underscore/nounderscore.go
./has_underscore/nounderscore/has_underscore.go
./has_underscore/nounderscore/nounderscore.go
./has_underscore/has_underscore/has_underscore.go
./has_underscore/has_underscore/nounderscore.go
```
</details>