### PR TITLE
fix regex to match output from git ls-files

### DIFF
--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -17,7 +17,7 @@ GO_ARCHIVE_FILES +=
 
 # GO_SOURCE_FILES is a space separated list of source files that are used by the
 # build process.
-GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.go' -not -regex '.*/_.*')
+GO_SOURCE_FILES += $(shell PATH="$(PATH)" git-find . -name '*.go' -not -regex '^_.*' -not -regex '.*\/_.*')
 
 # GO_EMBEDDED_FILES is a space separated list of files that are embedded into
 # the Go binary using the standard "embed" package.

--- a/pkg/protobuf/v1/Makefile
+++ b/pkg/protobuf/v1/Makefile
@@ -1,5 +1,5 @@
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '.*/_.*')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '^_.*' -not -regex '.*\/_.*')
 
 # PROTO_INCLUDE_PATHS is a space separate list of include paths to use when
 # building the .proto files from this repository.

--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -1,7 +1,7 @@
 MF_LANGUAGES += proto
 
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '.*/_.*')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '^_.*' -not -regex '.*\/_.*')
 
 # PROTO_GRPC_FILES is the subset of PROTO_FILES that contain gRPC service
 # definitions.


### PR DESCRIPTION
Didn't match the output from `git ls-files` when the underscore path was in the root of the project, so didn't work in all cases.

Quick fix.