### PR TITLE
Ignore symlinked protobuf files

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -1,7 +1,7 @@
 MF_LANGUAGES += proto
 
 # PROTO_FILES is a space separated list of Protocol Buffers files.
-PROTO_FILES += $(shell PATH="$(PATH)" git-find . -name '*.proto' -not -regex '^_.*' -not -regex '.*\/_.*')
+PROTO_FILES += $(shell PATH="$(PATH)" git-find . -type f -name '*.proto' -not -regex '^_.*' -not -regex '.*\/_.*')
 
 # PROTO_GRPC_FILES is the subset of PROTO_FILES that contain gRPC service
 # definitions.


### PR DESCRIPTION
We ran into an issue where symlinked copies of protobuf files were being included in `GENERATED_FILES` in a way that caused the `go` package to explode. The symlinked copies of the `.proto` files are used by an IDE that does its own generation, and were not intended to generate additional Go code.

This is a hacky fix to get us past the issue, but the `protobuf` and/or `go` packages probably need a way to either explicitly allow or explicitly disallow certain `.proto` files from having Go code generated for them.