### PR TITLE
Fix Telepresence `intercept`/`leave` deprecation warnings

### DIFF
--- a/pkg/telepresence/v2/bin/intercept
+++ b/pkg/telepresence/v2/bin/intercept
@@ -15,21 +15,33 @@ trap leave EXIT
 
 i=3 # account for $0, $workflow and "--" argument
 
+ctx=$(kubectl config current-context)
+ns=$(kubectl config view --minify -o jsonpath='{..namespace}')
+
 for port in ${@:2}; do
     if [[ "$port" == "--" ]]; then
         break
     fi
 
-    name="${workload}_${port}"
+    name="${ctx}_${ns}_${workload}_${port}"
     local_port="$((32768 + $RANDOM))"
 
-    telepresence intercept \
+    telepresence \
+        --use "$name" \
+        connect \
+        --name "$name" \
+        --context "$ctx" \
+        --namespace "$ns"
+    telepresence \
+        --use "$name" \
+        intercept \
         "$name" \
         --workload "$workload" \
         --port "${local_port}:${port}" \
         --env-file="${env_file}"
 
-    echo "telepresence leave '${name}'" >> "$defer"
+    echo "telepresence --use '${name}' connect --name '${name}' --context '${ctx}' --namespace '${ns}'" >> "$defer"
+    echo "telepresence --use '${name}' leave '${name}'" >> "$defer"
     ((i++))
 
     echo "TELEPRESENCE_PORT_${port}=$local_port" >> "$env_file"


### PR DESCRIPTION
This PR primarily addresses the following warning that's started appearing when intercepting:

> `Warning: You are executing the "telepresence intercept [flags] <intercept_base_name> [-- <command with arguments...>]" command without a preceding "telepresence connect", causing an implicit connect to take place. The implicit connect behavior is deprecated and will be removed in a future release.`

The warning can also appear for `telepresence leave` when closing an intercept that's been open for a long time (e.g. accidentally left open overnight).

I've also added a bunch of optional flags that seem to improve the experience when switching namespaces and re-intercepting. Previously, if you forget to `telepresence quit -s` after switching namespaces, the intercept would appear to work, but would have applied to the previous namespace. Now, when intercepting after a namespace switch, you'll get an error instead:

> `telepresence connect: error: connector.Connect: Cluster configuration changed, please quit telepresence and reconnect`

Which still sucks, but at least it's a decent reminder of what you need to do.

Relevant release notes:

- [`2.16.0`](https://www.getambassador.io/docs/telepresence/latest/release-notes#2.16.0)
  - A deprecation warning will be printed if a command other than `telepresence connect` causes an implicit connect to happen. Implicit connects will be removed in a future release.
  - The behavior changed so that a connected Telepresence client is bound to a namespace. The namespace can then not be changed unless the client disconnects and reconnects. A connection is also given a name. The default name is composed from `<kube context name>-<namespace>` but can be given explicitly when connecting using `--name`. The connection can optionally be identified using the option `--use <name match>` (only needed when docker is used and more than one connection is active). 