### PR TITLE
Add archive sums to Go package

### DIFF
--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -158,9 +158,13 @@ ifneq ($(GO_BUILD_BEFORE_TEST),)
 GO_TEST_REQ += $(_GO_DEBUG_TARGETS_HOST)
 endif
 
-# GO_ARCHIVES is the list of archive files to be build, based on the build
+# GO_ARCHIVES is the list of archive files to be built, based on the build
 # matrix.
 GO_ARCHIVES ?= $(addprefix artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-,$(addsuffix .zip,$(subst /,-,$(_GO_BUILD_PLATFORM_MATRIX_ALL))))
+
+# GO_ARCHIVE_SUMS is the list of archive checksum files to be built, based on
+# the build matrix.
+GO_ARCHIVE_SUMS ?= $(addsuffix .sha256,$(GO_ARCHIVES))
 
 ################################################################################
 
@@ -234,6 +238,9 @@ release: $(_GO_RELEASE_TARGETS_ALL)
 # additional files specified in GO_ARCHIVE_FILES.
 archives: $(GO_ARCHIVES)
 
+# archive-sums --- Generates checksums for all release archives.
+archive-sums: artifacts/archives/sums.sha256
+
 # pre-intercept --- Removes the debug binaries for the current architecture
 # before starting a Telepresence intercept, forcing them to be rebuild with
 # CGO_ENABLED within the intercept.
@@ -270,10 +277,19 @@ artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip: $(GO_ARCHIVE
 	@rm -f "$@"
 	zip --recurse-paths --junk-paths "$@" -- $^
 
+artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip.sha256: artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip
+	openssl dgst -sha256 "$<" | awk '{print $$2 "  $(notdir $<)"}' > "$@"
+
 artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip: $(GO_ARCHIVE_FILES) $$(addprefix artifacts/build/release/$$(subst -,/,$$*)/,$(_GO_BINARIES_NIX))
 	@mkdir -p "$(@D)"
 	@rm -f "$@"
 	zip --recurse-paths --junk-paths "$@" -- $^
+
+artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip.sha256: artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip
+	openssl dgst -sha256 "$<" | awk '{print $$2 "  $(notdir $<)"}' > "$@"
+
+artifacts/archives/sums.sha256: $(filter %.sha256,$(GO_ARCHIVE_SUMS))
+	cat $^ | sort -k 2 > $@
 
 artifacts/go/bin/golangci-lint:
 	$(MF_ROOT)/pkg/go/v1/bin/install-golangci-lint "$(MF_PROJECT_ROOT)/$(@D)"

--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -236,9 +236,11 @@ release: $(_GO_RELEASE_TARGETS_ALL)
 
 # archives --- Builds zip archives containing the release binaries and an
 # additional files specified in GO_ARCHIVE_FILES.
+.PHONY: archives
 archives: $(GO_ARCHIVES)
 
 # archive-sums --- Generates checksums for all release archives.
+.PHONY: archive-sums
 archive-sums: artifacts/archives/sums.sha256
 
 # pre-intercept --- Removes the debug binaries for the current architecture

--- a/pkg/go/v1/Makefile
+++ b/pkg/go/v1/Makefile
@@ -279,15 +279,12 @@ artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip: $(GO_ARCHIVE
 	@rm -f "$@"
 	zip --recurse-paths --junk-paths "$@" -- $^
 
-artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip.sha256: artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-windows-%.zip
-	openssl dgst -sha256 "$<" | awk '{print $$2 "  $(notdir $<)"}' > "$@"
-
 artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip: $(GO_ARCHIVE_FILES) $$(addprefix artifacts/build/release/$$(subst -,/,$$*)/,$(_GO_BINARIES_NIX))
 	@mkdir -p "$(@D)"
 	@rm -f "$@"
 	zip --recurse-paths --junk-paths "$@" -- $^
 
-artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip.sha256: artifacts/archives/$(PROJECT_NAME)-$(GO_APP_VERSION)-%.zip
+artifacts/archives/%.sha256: artifacts/archives/%
 	openssl dgst -sha256 "$<" | awk '{print $$2 "  $(notdir $<)"}' > "$@"
 
 artifacts/archives/sums.sha256: $(filter %.sha256,$(GO_ARCHIVE_SUMS))


### PR DESCRIPTION
This PR adds a new `archive-sums` target to the Go package. This target generates an `<archive filename>.sha256` file next to each archive, as well as a `sums.sha256` (containing sums for _all_ archives), using a format suitable for verifying with `sha256sum -c`, e.g.:

```
9e1f026282e73e492e05cebf825037f53c66ed4af6ec5ed2d34dfa56dbf0498c  example-0.0.0+304895d-darwin-amd64.zip
457af0032cd451368049053f18e85ff4f34a044e4d00508294e6c0c995fd05b4  example-0.0.0+304895d-darwin-arm64.zip
8d3160a97d7ba941c09597644413c1f147b16486472137d4c7d01637fb9414c6  example-0.0.0+304895d-linux-amd64.zip
8055a802064cc9f59f4d916d92bfcae3f8aaee868986d6e27daef5a0f3ea4004  example-0.0.0+304895d-linux-arm64.zip
```

The sum itself is calculated using `openssl`, because it is more widely available than `sha256sum` - it's installed by default on both macOS and GitHub Actions runners. On macOS `sha256sum` needs to be installed via `brew install coreutils` or similar.

The intent here is to make it easier to publish these sums in places like GitHub releases, for later use in Homebrew taps.