### PR TITLE
Junk paths in Swift protoc plugin zip for more consistent install

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -41,7 +41,7 @@ artifacts/protobuf/bin/protoc-gen-go artifacts/protobuf/bin/protoc-gen-go-grpc: 
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"
 
 artifacts/protobuf/bin/protoc-gen-swift artifacts/protobuf/bin/protoc-gen-grpc-swift:
-	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-swift "$(MF_PROJECT_ROOT)/artifacts/protobuf"
+	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-swift "$(MF_PROJECT_ROOT)/artifacts/protobuf/bin"
 
 artifacts/protobuf/args/common:
 	@mkdir -p "$(@D)"

--- a/pkg/protobuf/v2/bin/install-protoc-gen-swift
+++ b/pkg/protobuf/v2/bin/install-protoc-gen-swift
@@ -17,5 +17,5 @@ ARCHIVE="protoc-gen-swift.zip"
 mkdir -p "${PROTOC_ROOT}"
 pushd "${PROTOC_ROOT}"
 curl --fail --silent --show-error --location --output "${ARCHIVE}" "${URL}"
-unzip -o "${ARCHIVE}"
+unzip -oj "${ARCHIVE}"
 popd


### PR DESCRIPTION
The macOS and linux prebuilt plugins have different structures inside the zip. This fix makes less assumptions about what structure will be in the download, to make placing the tools in `/artifacts` more reliable.

I have tested this again on my local machine and on a GH CI run and it is now working in both cases for me.