### PR TITLE
Resolve symlinks in generate-include-paths

### DIFF
--- a/pkg/protobuf/v2/bin/generate-include-paths
+++ b/pkg/protobuf/v2/bin/generate-include-paths
@@ -12,6 +12,6 @@ do
     if [[ $proto_file_count -gt 0 ]]; then
        # Print the protobuf include path to the standard output
        # if the Go module directory contains *.proto files.
-       echo "--proto_path=$path=$dir"
+       echo "--proto_path=$path=$(realpath "$dir")"
     fi
 done


### PR DESCRIPTION
Fixes an issue when a go module exists inside a symlink somewhere in its filesystem path which would end up causing errors with protoc not being able to also resolve the symlink eg. when that symlink was used to CD into the module when the include path artifacts are generated.