### PR TITLE
Support externally installed protoc in protobuf v2

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -20,7 +20,7 @@ PROTO_INCLUDE_PATHS ?=
 # the latest version of protoc is installed for the host operating system.
 PROTOC_COMMAND ?= $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc
 
-# PROTO_PROTOC_PATH is the path the script file that includes
+# PROTO_PROTOC_PATH is the path to the script file that includes
 # $(MF_PROJECT_ROOT)/artifacts/protobuf/bin directory in the PATH environment
 # variable when the script is executed.
 PROTO_PROTOC_PATH = $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/run-protoc
@@ -35,7 +35,7 @@ $(MF_PROJECT_ROOT)/artifacts/protobuf/bin/protoc:
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc "$(MF_PROJECT_ROOT)/artifacts/protobuf"
 
 artifacts/protobuf/bin/run-protoc: $(PROTOC_COMMAND)
-	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-run-protoc $(PROTOC_COMMAND)
+	$(MF_ROOT)/pkg/protobuf/v2/bin/generate-run-protoc $(PROTOC_COMMAND) "$@"
 
 artifacts/protobuf/bin/protoc-gen-go artifacts/protobuf/bin/protoc-gen-go-grpc: go.mod
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"
@@ -45,8 +45,7 @@ artifacts/protobuf/bin/protoc-gen-swift artifacts/protobuf/bin/protoc-gen-grpc-s
 
 artifacts/protobuf/args/common:
 	@mkdir -p "$(@D)"
-	echo "--proto_path=$(dir $(PROTOC_COMMAND))../include" > "$@"
-	echo $(addprefix --proto_path=,$(PROTO_INCLUDE_PATHS)) >> "$@"
+	echo $(addprefix --proto_path=,$(PROTO_INCLUDE_PATHS)) > "$@"
 
 # This Makefile provides the recipes used to build each language's source files
 # from the .proto files, but it does NOT automatically add these source files to

--- a/pkg/protobuf/v2/bin/generate-run-protoc
+++ b/pkg/protobuf/v2/bin/generate-run-protoc
@@ -2,17 +2,17 @@
 set -euo pipefail
 
 protoc_path=$1
-dir=$(dirname "${protoc_path}")
-script_name="run-protoc"
+run_protoc_path=$2
+run_protoc_dir=$(dirname "${run_protoc_path}")
 
-$(cat <<EOF > "${dir}/${script_name}"
+$(cat <<EOF > "$run_protoc_path"
 #!/usr/bin/env bash
 set -euo pipefail
 
 # Configure PATH so that the protoc plugins installed by the Makefiles take
 # precedence.
-PATH="${dir}:\$PATH" "$1" "\${@}"
+PATH="${run_protoc_dir}:\$PATH" "$protoc_path" "\${@}"
 EOF
 )
 
-chmod +x "${dir}/${script_name}"
+chmod +x "$run_protoc_path"


### PR DESCRIPTION
This PR changes the way execution of `protoc` is handled to better support installation of `protoc` via tools like https://asdf-vm.com/

With these changes merged, projects will be able to opt-in to using an externally installed `protoc` binary by placing the following line above their package imports in `Makefile`:

```Makefile
PROTOC_COMMAND ?= $(shell which protoc)
```

We're also considering changing the default behaviour of the `protobuf` package in a future version (e.g. `v3`) to NOT install `protoc`, in favour of using external installation, like we do for most tools the makefiles rely on.

> [!NOTE]
> In our testing, it seems like the `include` directory bundled with `protoc` no longer needs to be explicitly added to the include paths via `--proto_path=`.