### PR TITLE
Hardcode `grpc-swift` version

### DIFF
--- a/pkg/protobuf/v2/bin/install-protoc-gen-swift
+++ b/pkg/protobuf/v2/bin/install-protoc-gen-swift
@@ -11,7 +11,7 @@ case "$(uname -s)" in
 esac
 
 QUERY=".assets[] | select(.name | contains(\"linux-x86_64\") == ${IS_LINUX}) | .browser_download_url"
-URL=$(curl https://api.github.com/repos/grpc/grpc-swift/releases/latest | jq -r "${QUERY}")
+URL=$(curl https://api.github.com/repos/grpc/grpc-swift/releases/184697892 | jq -r "${QUERY}")
 ARCHIVE="protoc-gen-swift.zip"
 
 mkdir -p "${PROTOC_ROOT}"


### PR DESCRIPTION
Temporary fix for installing swift protoc plugins