### PR TITLE
Build plugins from package

### DIFF
--- a/pkg/protobuf/v2/Makefile
+++ b/pkg/protobuf/v2/Makefile
@@ -41,7 +41,7 @@ artifacts/protobuf/bin/protoc-gen-go artifacts/protobuf/bin/protoc-gen-go-grpc: 
 	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-go "$(MF_PROJECT_ROOT)/$(@D)"
 
 artifacts/protobuf/bin/protoc-gen-swift artifacts/protobuf/bin/protoc-gen-grpc-swift:
-	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-swift "$(MF_PROJECT_ROOT)/artifacts/protobuf/bin"
+	$(MF_ROOT)/pkg/protobuf/v2/bin/install-protoc-gen-swift "$(MF_PROJECT_ROOT)/artifacts/protobuf/bin" $(PROTO_SWIFT_OUT)
 
 artifacts/protobuf/args/common:
 	@mkdir -p "$(@D)"

--- a/pkg/protobuf/v2/bin/install-protoc-gen-swift
+++ b/pkg/protobuf/v2/bin/install-protoc-gen-swift
@@ -3,19 +3,13 @@ set -euo pipefail
 
 PROTOC_ROOT="${1}"
 
-case "$(uname -s)" in
-    "Darwin")
-      IS_LINUX=false;;
-    *)
-      IS_LINUX=true;;
-esac
+swift build -c release --product protoc-gen-swift
+swift build -c release --product protoc-gen-grpc-swift
 
-QUERY=".assets[] | select(.name | contains(\"linux-x86_64\") == ${IS_LINUX}) | .browser_download_url"
-URL=$(curl https://api.github.com/repos/grpc/grpc-swift/releases/184697892 | jq -r "${QUERY}")
-ARCHIVE="protoc-gen-swift.zip"
+PROTOC_SWIFT="$(swift build -c release --product protoc-gen-swift --show-bin-path)/protoc-gen-swift"
+PROTOC_GRPC_SWIFT="$(swift build -c release --product protoc-gen-grpc-swift --show-bin-path)/protoc-gen-grpc-swift"
 
 mkdir -p "${PROTOC_ROOT}"
 pushd "${PROTOC_ROOT}"
-curl --fail --silent --show-error --location --output "${ARCHIVE}" "${URL}"
-unzip -oj "${ARCHIVE}"
+cp $PROTOC_SWIFT $PROTOC_GRPC_SWIFT .
 popd

--- a/pkg/protobuf/v2/bin/install-protoc-gen-swift
+++ b/pkg/protobuf/v2/bin/install-protoc-gen-swift
@@ -2,6 +2,19 @@
 set -euo pipefail
 
 PROTOC_ROOT="${1}"
+PROTO_SWIFT_OUT="${2}"
+
+SWIFT_TARGET_EMPTY=${! find "${PROTO_SWIFT_OUT}" -type f -name "*.swift" | grep -q .}
+
+if SWIFT_TARGET_EMPTY; then
+  echo "No Swift files found in the target directory. Adding an empty.swift"
+
+  mkdir -p "${PROTO_SWIFT_OUT}"
+
+  echo "// This file is generated to workaround using SPM with a temporarily empty target.\n" \
+    "// Track discussion on [this issue](https://github.com/swiftlang/swift-package-manager/issues/8061)." \
+    >>"${PROTO_SWIFT_OUT}/empty.swift"
+fi
 
 swift build -c release --product protoc-gen-swift
 swift build -c release --product protoc-gen-grpc-swift
@@ -13,3 +26,7 @@ mkdir -p "${PROTOC_ROOT}"
 pushd "${PROTOC_ROOT}"
 cp $PROTOC_SWIFT $PROTOC_GRPC_SWIFT .
 popd
+
+if SWIFT_TARGET_EMPTY; then
+  rm -f "${PROTO_SWIFT_OUT}/empty.swift"
+fi


### PR DESCRIPTION
It appears the `grpc-swift` project maintainers are recommending we build the plugins from source rather than downloading a precompiled version as we were before.

This change removes the hardcoded download of `grpc-swift v1.24.0` and uses `SPM` to install the version pinned in `Package.swift`.