### PR TITLE
Add `xargs` command to `verify-generated-files` script.

### DIFF
--- a/lib/core/bin/verify-generated-files
+++ b/lib/core/bin/verify-generated-files
@@ -2,7 +2,7 @@
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../include/common.bash"
 
-files="$(make list-generated --no-print-directory)"
+files="$(make --no-print-directory list-generated)"
 if [[ -z "$files" ]]; then
     exit 0
 fi

--- a/lib/core/bin/verify-generated-files
+++ b/lib/core/bin/verify-generated-files
@@ -2,11 +2,12 @@
 set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/../include/common.bash"
 
-if [[ $# = 0 ]]; then
+files="$(make list-generated --no-print-directory)"
+if [[ -z "$files" ]]; then
     exit 0
 fi
 
 log "checking for out-of-date generated files"
-rm -f -- "$@"
-make --no-print-directory "$@"
-git diff --exit-code -- "$@"
+echo "$files" | xargs rm -f
+echo "$files" | xargs make --no-print-directory
+echo "$files" | xargs git diff --exit-code

--- a/lib/core/include/common.mk
+++ b/lib/core/include/common.mk
@@ -166,7 +166,7 @@ try-regenerate::
 # differences are detected.
 .PHONY: verify-generated
 verify-generated:
-	@PATH="$(PATH)" verify-generated-files $(GENERATED_FILES)
+	@PATH="$(PATH)" verify-generated-files
 
 # list-generated --- Lists all files in the GENERATED_FILES list that are
 # tracked by git.
@@ -203,7 +203,7 @@ precommit:: $$(GENERATED_FILES)
 # recipies for this target.
 .PHONY: ci
 ci::
-	@PATH="$(PATH)" verify-generated-files $(GENERATED_FILES)
+	@PATH="$(PATH)" verify-generated-files
 
 ifeq ($(CI_RUN_BENCHMARKS),true)
 ci:: benchmark


### PR DESCRIPTION
This PR pipes changes `lib/core/bin/verify-generated-files` script to pipe all generated files through `xargs` command to avoid failures like `/bin/sh: Argument list too long`. 