### PR TITLE
Add support for vite config files

### DIFF
--- a/pkg/js/v1/Makefile
+++ b/pkg/js/v1/Makefile
@@ -18,6 +18,9 @@ JS_JEST_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file jest.conf
 # JS_NEXT_CONFIG_FILE is the path to any existing Next.js configuration.
 JS_NEXT_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file next.config.ts next.config.js next.config.mjs)
 
+# JS_VITE_CONFIG_FILE is the path to any existing Vite configuration.
+JS_VITE_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file vite.config.ts vite.config.js vite.config.mjs)
+
 # JS_PLAYWRIGHT_TEST_CONFIG_FILE is the path to any existing Playwright Test configuration.
 JS_PLAYWRIGHT_TEST_CONFIG_FILE ?= $(shell PATH="$(PATH)" find-first-matching-file playwright.config.*)
 
@@ -104,6 +107,10 @@ node_modules: artifacts/link-dependencies.touch
 
 ifneq ($(JS_NEXT_CONFIG_FILE),)
 -include .makefiles/pkg/js/v1/include/next.mk
+endif
+
+ifneq ($(JS_VITE_CONFIG_FILE),)
+-include .makefiles/pkg/js/v1/include/vite.mk
 endif
 
 ifneq ($(JS_WEBPACK_CONFIG_FILE),)

--- a/pkg/js/v1/include/vite.mk
+++ b/pkg/js/v1/include/vite.mk
@@ -1,0 +1,33 @@
+# JS_VITE_PORT is the port number that the Vite application should listen on.
+JS_VITE_PORT ?= 3000
+
+# JS_VITE_REQ is a space separated list of prerequisites needed to run Vite.
+JS_VITE_REQ +=
+
+################################################################################
+
+# _JS_VITE_REQ is a space separated list of automatically detected prerequisites
+# needed to run Vite.
+_JS_VITE_REQ += artifacts/link-dependencies.touch $(JS_VITE_CONFIG_FILE) $(JS_SOURCE_FILES) $(GENERATED_FILES)
+
+################################################################################
+
+# vite-build --- Compile the Vite application for production deployment.
+.PHONY: vite-build
+vite-build: artifacts/vite/dist/index.html
+
+# vite-dev --- Start the Vite application in development mode.
+.PHONY: vite-dev
+vite-dev: artifacts/link-dependencies.touch
+	NODE_ENV=development $(JS_EXEC) vite dev --port $(JS_VITE_PORT)
+
+# vite-preview --- Preview the production build of the Vite application.
+.PHONY: vite-preview
+vite-preview: artifacts/vite/dist/index.html
+	$(JS_EXEC) vite preview --port $(JS_VITE_PORT)
+
+################################################################################
+
+artifacts/vite/dist/index.html: $(JS_VITE_REQ) $(_JS_VITE_REQ)
+	@rm -rf "$@"
+	$(JS_EXEC) vite build

--- a/pkg/js/v1/with-vite.mk
+++ b/pkg/js/v1/with-vite.mk
@@ -1,0 +1,3 @@
+# release --- Produce all build assets necessary for a release.
+.PHONY: release
+release:: vite-build


### PR DESCRIPTION
This PR adds support for Vite projects. It operates almost identically to the Next.JS include of which it was based.

Vite is useful for some projects where, for example, building a full Next.JS project is not ideal, or where CSR-only is acceptable.